### PR TITLE
Updated README to include setuptools dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Build
 We use lilv to scan plugins, phantomjs to render screenshots and `pillow`_ to build png images.
 If you use a Debian-based GNU/Linux distribution (like Ubuntu), you can install all this with::
 
-    $ sudo apt-get install liblilv-dev phantomjs python3-pil python3-pystache python3-tornado
+    $ sudo apt-get install liblilv-dev phantomjs python3-pil python3-pystache python3-tornado python3-setuptools
 
 After you have all dependencies installed, build it with::
 


### PR DESCRIPTION
The docker image for building plugins doesn't have setuptools on it, so although most people will have it already, this might help a few people out. 