### PR TITLE
Update dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,10 @@ To use the SDK, developers should adjust their LV2_PATH to where LV2 bundles res
 Build
 -------
 
-We use lilv to scan plugins, phantomjs to render screenshots and `pillow`_ to build png images.
+We use python 3.5, `lilv` to scan plugins, `phantomjs` to render screenshots and `pillow`_ to build png images.
 If you use a Debian-based GNU/Linux distribution (like Ubuntu), you can install all this with::
 
-    $ sudo apt-get install build-essential liblilv-dev phantomjs python3-pil python3-pystache python3-tornado python3-setuptools
+    $ sudo apt-get install build-essential liblilv-dev phantomjs python3-pil python3-pystache python3-tornado python3-setuptools python3-pyinotify
 
 After you have all dependencies installed, build it with::
 


### PR DESCRIPTION
Hi,

Here is few fixes on the readme.

- I try to use python 3.8, 3.7, 3.6. Nothing was working cause the tornado `web.asynchonous` do not exists anymore. I guess because of the new python `asyn` keyword. It is working with python 3.5.
- `python3-inotify` looks to be expected now

On side note, i created on my side, a conda requirement file, in case you are interested in a small how to with conda.