### PR TITLE
Avoid infinite polling of the file system

### DIFF
--- a/modsdk/bundlemonitor.py
+++ b/modsdk/bundlemonitor.py
@@ -29,7 +29,7 @@ class BundleMonitor:
 
         self.mask = pyinotify.IN_DELETE | pyinotify.IN_CREATE  | pyinotify.IN_CLOSE_WRITE
         self.wm = pyinotify.WatchManager()
-        self.notifier = pyinotify.Notifier(self.wm, EventHandler(self), timeout=0)
+        self.notifier = pyinotify.Notifier(self.wm, EventHandler(self), timeout=100)
 
     def monitor(self, bundle):
         self.clear()


### PR DESCRIPTION
Hi,

Here is a fix to avoid to poll the files million of time per seconds.

One of my core was dedicate to loop here.

I set it to 100ms. It could be smaller, but for human interaction i think it is enough.

Regards,