### PR TITLE
Fix film for discrete knoks

### DIFF
--- a/html/js/modgui.js
+++ b/html/js/modgui.js
@@ -1658,7 +1658,7 @@ JqueryClass('film', baseWidget, {
         // in this theoric case.
             rotation = Math.round(filmSteps / 2)
         } else if (portSteps != null) {
-            rotation = Math.round(steps) * Math.round(filmSteps / (portSteps))
+            rotation = Math.round(steps) * Math.round((filmSteps - 1) / (portSteps - 1))
         }
 
         rotation = Math.min(filmSteps-1, Math.max(0, rotation))


### PR DESCRIPTION
Hi,

Here is a fix to use the full available film in case of discrete knoks.

That is important cause i have to align this knok with labels for each discrete values.

Is this code also used for the Mod Duo server? Or it have to be backported?

Here is an example with a knok with 6 values (integer from 0 to 5 included). On the left the `master`, on the right the fix.
![fix-discrite-knoks](https://user-images.githubusercontent.com/7579321/70378083-c13cfe00-191c-11ea-9e37-5a94f6b8ce14.png)

The code still looks weird cause a double round sounds like it is possible to accumulate many delta error. But i mostly understand nothing to the code (what is `steps` and so on).