### PR TITLE
Tune footswitch image size

### DIFF
--- a/html/css/pedals.css
+++ b/html/css/pedals.css
@@ -459,7 +459,7 @@ body > .mod-settings.mod-window-visible {
     background-image:url(/resources/pedals/footswitch.png);
     background-position:left center;
     background-repeat:no-repeat;
-    background-size:auto 64px;
+    background-size:64px auto;
     height:64px;
     left:47px;
     position:absolute;


### PR DESCRIPTION
Hi,

I was working on trigger control and i saw a small glitch.

It looks like the footswitch sprite film to not have anymore the same orientation.

This PR only fix the display, but the animation looks to be not working. Maybe you still have to investigate something.

Here was it was displayed with modsdk master:
![trigger glitch](https://user-images.githubusercontent.com/7579321/70852470-083d6d00-1ea2-11ea-8f73-7b2cf7339093.png)

On the the last Mod Device release installed on my device, i don't have the same sprite, nor the same code. And there was another glitch: when clicking on the button the sprite have a small gap, then i tune this same property this way: `background-size:127px 64px;`. I don't know which version is in the truth.