### PR TITLE
Debian needs python3-pyinotify

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Build
 We use lilv to scan plugins, phantomjs to render screenshots and `pillow`_ to build png images.
 If you use a Debian-based GNU/Linux distribution (like Ubuntu), you can install all this with::
 
-    $ sudo apt-get install build-essential liblilv-dev phantomjs python3-pil python3-pystache python3-tornado python3-setuptools
+    $ sudo apt-get install build-essential liblilv-dev phantomjs python3-pil python3-pystache python3-tornado python3-setuptools python3-pyinotify
 
 After you have all dependencies installed, build it with::
 


### PR DESCRIPTION
I had to install python3-pyinotify on Debian 10 so that ./development_server.py would be able to import pyinotify and run