### PR TITLE
feat(noBundles) add suggestion for user to resolve error

### DIFF
--- a/html/css/sdk.css
+++ b/html/css/sdk.css
@@ -67,7 +67,7 @@ ul#menu li.selected {
 
 #no-bundles {
     color: white;
-    margin: 40px 0 0 10px;
+    margin: 40px 45px;
 }
 
 #version {

--- a/html/index.html
+++ b/html/index.html
@@ -244,8 +244,11 @@
         <!-- /content-wrapper -->
 
         <div id="no-bundles">
-          <h2>No bundles found!</h2>
-          <p>Install some LV2 plugins please.</p>
+            <h2>Install plugins to get started.</h2>
+            <p>No lv2 bundles were found.</p>
+            <p>Get started by installing some using your package manager.</p>
+            <p>If you use a Debian-based GNU/Linux distribution (like Ubuntu), try installing Guitarix with the command:</p>
+            <pre><code>sudo apt install guitarix-lv2</code></pre>
         </div>
 
         <!-- PEDALBOARD-DASHBOARD -->


### PR DESCRIPTION
## Description

If no LV2 plugins are installed, the mod-sdk can't load.

This PR adds a clearer next step to install LV2 plugins to get started with the mod-sdk.

The hope is more folk realise their install is successful, and by giving a clear next step, more folk contribute plugins to the mod platform.

## Screenshots

| Before | After |
| ------ | ----- |
|   ![raspberrypi local_9000__v=1675459194 (1)](https://user-images.githubusercontent.com/54108045/216720722-9646331c-c198-486b-b3c7-31c6e44b1533.png) |  ![raspberrypi local_9000__v=1675459194](https://user-images.githubusercontent.com/54108045/216720001-c7ccfc36-2fe9-4fb8-a372-89595c0ab83a.png) |
